### PR TITLE
Adjusted main nav alignment to center

### DIFF
--- a/style.css
+++ b/style.css
@@ -193,6 +193,7 @@ input[type='submit']:hover {
 	margin: 0 auto;
 	max-width: 62rem;
 	padding: 0 1rem;
+	text-align: center;
 }
 
 .main-navigation ul li.current-menu-item>a,.main-navigation ul li.current_page_item>a,.main-navigation ul li.current_page_ancestor>a,.main-navigation ul li.current-menu-parent>a {
@@ -274,6 +275,7 @@ input[type='submit']:hover {
 	display: none;
 	padding: .66667rem 1.125rem;
 	position: absolute;
+	text-align: left;
 	top: 4.35em;
 	width: auto;
 }


### PR DESCRIPTION
We can re-adjust, if needed, later on. If the nav list items grow (we add more links), we will probably want to shift the alignment back to the left.

With a smaller amount of nav links, however, I think it looks better to center them on the page.